### PR TITLE
Split up SidebarContext to fix slow state change with the alerts map

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,8 @@ import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types.d.ts';
 import * as React from 'react';
 
+import { SelectedAlertProvider } from '@/domain/contexts/SelectedAlertContext';
+import { SelectedMapProvider } from '@/domain/contexts/SelectedMapContext';
 import { SidebarProvider } from '@/domain/contexts/SidebarContext';
 
 export interface ProvidersProps {
@@ -19,7 +21,11 @@ export function Providers({ children, themeProps }: ProvidersProps) {
   return (
     <NextUIProvider navigate={router.push}>
       <NextThemesProvider defaultTheme="system" {...themeProps}>
-        <SidebarProvider>{children} </SidebarProvider>
+        <SidebarProvider>
+          <SelectedMapProvider>
+            <SelectedAlertProvider>{children}</SelectedAlertProvider>
+          </SelectedMapProvider>
+        </SidebarProvider>
       </NextThemesProvider>
     </NextUIProvider>
   );

--- a/src/components/AlertsMenu/AlertsMenu.tsx
+++ b/src/components/AlertsMenu/AlertsMenu.tsx
@@ -5,13 +5,13 @@ import { useMemo } from 'react';
 
 import { AlertButton } from '@/components/AlertsMenu/AlertButton';
 import { Tooltip } from '@/components/Tooltip/Tooltip';
-import { useSidebar } from '@/domain/contexts/SidebarContext';
+import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { AlertType } from '@/domain/enums/AlertType';
 import { AlertsMenuProps } from '@/domain/props/AlertsMenuProps';
 import { SidebarOperations } from '@/operations/sidebar/SidebarOperations';
 
 export function AlertsMenu({ variant }: AlertsMenuProps) {
-  const { isAlertSelected, toggleAlert } = useSidebar();
+  const { isAlertSelected, toggleAlert } = useSelectedAlert();
 
   const isSubAlertClicked = useMemo(
     () => (mainAlert: AlertType) => {

--- a/src/components/Legend/MapLegend.tsx
+++ b/src/components/Legend/MapLegend.tsx
@@ -2,10 +2,10 @@
 
 import LegendContainer from '@/components/Legend/LegendContainer';
 import { mapLegendData } from '@/domain/constant/legend/mapLegendData.ts';
-import { useSidebar } from '@/domain/contexts/SidebarContext';
+import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
 
 export default function MapLegend() {
-  const { selectedMapType } = useSidebar();
+  const { selectedMapType } = useSelectedMap();
   return (
     <div className="absolute bottom-5 right-0 z-50 pr-10">
       <LegendContainer items={mapLegendData(selectedMapType)} />

--- a/src/components/Map/Alerts/AlertContainer.tsx
+++ b/src/components/Map/Alerts/AlertContainer.tsx
@@ -1,10 +1,10 @@
-import { useSidebar } from '@/domain/contexts/SidebarContext';
+import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { AlertType } from '@/domain/enums/AlertType';
 
 import { ConflictLayer } from './ConflictLayer';
 
 export function AlertContainer() {
-  const { selectedAlert } = useSidebar();
+  const { selectedAlert } = useSelectedAlert();
 
   switch (selectedAlert) {
     case AlertType.CONFLICTS:

--- a/src/components/Map/VectorTileLayer.tsx
+++ b/src/components/Map/VectorTileLayer.tsx
@@ -5,7 +5,7 @@ import mapboxgl from 'mapbox-gl'; // eslint-disable-line import/no-webpack-loade
 import { useTheme } from 'next-themes';
 import React, { RefObject, useEffect, useRef } from 'react';
 
-import { useSidebar } from '@/domain/contexts/SidebarContext';
+import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
 import { MapProps } from '@/domain/props/MapProps';
 import { MapOperations } from '@/operations/map/MapOperations.ts';
 
@@ -13,7 +13,7 @@ export default function VectorTileLayer({ countries, disputedAreas }: MapProps) 
   const { theme } = useTheme();
   const context: LeafletContextInterface = useLeafletContext();
   const mapContainer: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
-  const { selectedMapType } = useSidebar();
+  const { selectedMapType } = useSelectedMap();
 
   mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 

--- a/src/components/Sidebar/CollapsedSidebar.tsx
+++ b/src/components/Sidebar/CollapsedSidebar.tsx
@@ -3,11 +3,13 @@ import { Card, CardBody, CardHeader } from '@nextui-org/card';
 import { SidebarRight } from 'iconsax-react';
 import NextImage from 'next/image';
 
+import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
 import { useSidebar } from '@/domain/contexts/SidebarContext';
 import { SidebarOperations } from '@/operations/sidebar/SidebarOperations';
 
 export function CollapsedSidebar() {
-  const { toggleSidebar, selectedMapType, setSelectedMapType } = useSidebar();
+  const { toggleSidebar } = useSidebar();
+  const { selectedMapType, setSelectedMapType } = useSelectedMap();
 
   return (
     <div className="absolute top-0 left-0 z-50 p-4">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -15,6 +15,7 @@ import { CollapsedSidebar } from '@/components/Sidebar/CollapsedSidebar';
 import { ThemeSwitch } from '@/components/Sidebar/ThemeSwitch';
 import { pageLinks } from '@/domain/constant/PageLinks';
 import { SUBSCRIBE_MODAL_TITLE } from '@/domain/constant/subscribe/Subscribe';
+import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
 import { useSidebar } from '@/domain/contexts/SidebarContext';
 import { AlertsMenuVariant } from '@/domain/enums/AlertsMenuVariant';
 import { SidebarOperations } from '@/operations/sidebar/SidebarOperations';
@@ -23,7 +24,8 @@ import PopupModal from '../PopupModal/PopupModal';
 import Subscribe from '../Subscribe/Subscribe';
 
 export function Sidebar() {
-  const { isSidebarOpen, toggleSidebar, selectedMapType, setSelectedMapType } = useSidebar();
+  const { isSidebarOpen, toggleSidebar } = useSidebar();
+  const { selectedMapType, setSelectedMapType } = useSelectedMap();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   if (!isSidebarOpen) {

--- a/src/domain/contexts/SelectedAlertContext.tsx
+++ b/src/domain/contexts/SelectedAlertContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+import { AlertType } from '../enums/AlertType';
+
+interface SelectedAlertsState {
+  selectedAlert: AlertType | null;
+  setSelectedAlert: (value: AlertType) => void;
+  isAlertSelected: (alertType: AlertType) => boolean;
+  toggleAlert: (alertType: AlertType) => void;
+}
+
+const SelectedAlertContext = createContext<SelectedAlertsState | undefined>(undefined);
+
+export function SelectedAlertProvider({ children }: { children: ReactNode }) {
+  const [selectedAlert, setSelectedAlert] = useState<AlertType | null>(AlertType.HUNGER);
+
+  const isAlertSelected = (alertType: AlertType) => selectedAlert === alertType;
+  const toggleAlert = (alertType: AlertType) =>
+    isAlertSelected(alertType) ? setSelectedAlert(null) : setSelectedAlert(alertType);
+
+  const value = useMemo(
+    () => ({
+      selectedAlert,
+      setSelectedAlert,
+      isAlertSelected,
+      toggleAlert,
+    }),
+    [selectedAlert]
+  );
+
+  return <SelectedAlertContext.Provider value={value}>{children}</SelectedAlertContext.Provider>;
+}
+
+export function useSelectedAlert() {
+  const context = useContext(SelectedAlertContext);
+  if (!context) {
+    throw new Error('useSelectedAlert must be used within a SelectedAlertProvider');
+  }
+  return context;
+}

--- a/src/domain/contexts/SelectedMapContext.tsx
+++ b/src/domain/contexts/SelectedMapContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+import { GlobalInsight } from '../enums/GlobalInsight';
+
+interface SelectedMapTypeState {
+  selectedMapType: GlobalInsight;
+  setSelectedMapType: (value: GlobalInsight) => void;
+}
+
+const SelectedMapContext = createContext<SelectedMapTypeState | undefined>(undefined);
+
+export function SelectedMapProvider({ children }: { children: ReactNode }) {
+  const [selectedMapType, setSelectedMapType] = useState<GlobalInsight>(GlobalInsight.FOOD);
+
+  const value = useMemo(
+    () => ({
+      selectedMapType,
+      setSelectedMapType,
+    }),
+    [selectedMapType]
+  );
+
+  return <SelectedMapContext.Provider value={value}>{children}</SelectedMapContext.Provider>;
+}
+
+export function useSelectedMap() {
+  const context = useContext(SelectedMapContext);
+  if (!context) {
+    throw new Error('useSelectedMap must be used within a SelectedMapProvider');
+  }
+  return context;
+}

--- a/src/domain/contexts/SidebarContext.tsx
+++ b/src/domain/contexts/SidebarContext.tsx
@@ -2,21 +2,6 @@
 
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 
-import { AlertType } from '@/domain/enums/AlertType';
-import { GlobalInsight } from '@/domain/enums/GlobalInsight';
-
-interface SelectedMapTypeState {
-  selectedMapType: GlobalInsight;
-  setSelectedMapType: (value: GlobalInsight) => void;
-}
-
-interface SelectedAlertsState {
-  selectedAlert: AlertType | null;
-  setSelectedAlert: (value: AlertType) => void;
-  isAlertSelected: (alertType: AlertType) => boolean;
-  toggleAlert: (alertType: AlertType) => void;
-}
-
 interface SidebarState {
   isSidebarOpen: boolean;
   toggleSidebar: () => void;
@@ -24,37 +9,23 @@ interface SidebarState {
   closeSidebar: () => void;
 }
 
-interface SidebarContextType extends SidebarState, SelectedMapTypeState, SelectedAlertsState {}
-
-const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+const SidebarContext = createContext<SidebarState | undefined>(undefined);
 
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [selectedMapType, setSelectedMapType] = useState<GlobalInsight>(GlobalInsight.FOOD);
-  const [selectedAlert, setSelectedAlert] = useState<AlertType | null>(AlertType.HUNGER);
 
   const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
   const openSidebar = () => setIsSidebarOpen(true);
   const closeSidebar = () => setIsSidebarOpen(false);
 
-  const isAlertSelected = (alertType: AlertType) => selectedAlert === alertType;
-  const toggleAlert = (alertType: AlertType) =>
-    isAlertSelected(alertType) ? setSelectedAlert(null) : setSelectedAlert(alertType);
-
   const value = useMemo(
     () => ({
       isSidebarOpen,
-      selectedMapType,
-      selectedAlert,
       toggleSidebar,
       openSidebar,
       closeSidebar,
-      setSelectedMapType,
-      setSelectedAlert,
-      isAlertSelected,
-      toggleAlert,
     }),
-    [isSidebarOpen, selectedMapType, selectedAlert]
+    [isSidebarOpen]
   );
 
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;


### PR DESCRIPTION
Previously, whenever the state of the sidebar changed (e.g it was opened or closed), the current alert layer was rerendered, because it used the `selectedAlert` property of the same `SidebarContext`. Not sure if it's normal that this rerender took so long, but I could solve the real issue by splitting up the context into three contexts. Changing the sidebar state had no effect on the selected map and alert (and vice-versa), so we lose nothing but now the components are only rerendered when needed.