### PR TITLE
fix: fix margins for AlertsMenu, MapLegend, Sidebar

### DIFF
--- a/src/components/AlertsMenu/AlertsMenuWrapper.tsx
+++ b/src/components/AlertsMenu/AlertsMenuWrapper.tsx
@@ -11,7 +11,7 @@ export function AlertsMenuWrapper() {
     return null;
   }
   return (
-    <div className="absolute bottom-0 left-0 z-50 p-4">
+    <div className="absolute bottom-0 left-0 z-50 mb-10 ml-4">
       <AlertsMenu variant={AlertsMenuVariant.Outside} />
     </div>
   );

--- a/src/components/Legend/MapLegend.tsx
+++ b/src/components/Legend/MapLegend.tsx
@@ -19,7 +19,7 @@ export default function MapLegend() {
   }, [selectedAlert, selectedMapType]);
 
   return (
-    <div className="absolute bottom-5 right-0 z-50 pr-10">
+    <div className="absolute bottom-0 right-0 z-50 mr-10 mb-5">
       <LegendContainer items={items} />
     </div>
   );

--- a/src/components/Sidebar/CollapsedSidebar.tsx
+++ b/src/components/Sidebar/CollapsedSidebar.tsx
@@ -12,7 +12,7 @@ export function CollapsedSidebar() {
   const { selectedMapType, setSelectedMapType } = useSelectedMap();
 
   return (
-    <div className="absolute top-0 left-0 z-50 p-4">
+    <div className="absolute top-0 left-0 z-50 mt-4 ml-4">
       <Card className="h-full">
         <CardHeader className="flex justify-center items-center">
           <Button isIconOnly variant="light" onClick={toggleSidebar} aria-label="Close sidebar">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -33,7 +33,7 @@ export function Sidebar() {
   }
 
   return (
-    <div className="absolute top-0 left-0 z-50 h-screen mt-4 ml-4">
+    <div className="absolute top-0 left-0 z-50 mt-4 ml-4 mb-10 h-[calc(100vh-3.5rem)]">
       <Card
         classNames={{
           base: 'h-full',

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -33,7 +33,7 @@ export function Sidebar() {
   }
 
   return (
-    <div className="absolute top-0 left-0 z-50 h-screen p-4">
+    <div className="absolute top-0 left-0 z-50 h-screen mt-4 ml-4">
       <Card
         classNames={{
           base: 'h-full',

--- a/src/operations/map/MapOperations.tsx
+++ b/src/operations/map/MapOperations.tsx
@@ -40,6 +40,7 @@ export class MapOperations {
     const { countries } = mapProps
     return new mapboxgl.Map({
       container: mapContainer.current as unknown as string | HTMLElement,
+      logoPosition: 'bottom-left',  // default which can be changed to 'bottom-right'
       style: {
         version: 8,
         name: 'HungerMap LIVE',


### PR DESCRIPTION
- moved alerts menu above the mapbox logo
- fixed the map legend hiding the zoom control

Mapbox logo could potentially be moved to the right too