### PR TITLE
fix: remove rectangle which appears when click/focus over the region

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -102,6 +102,11 @@ canvas.react-pdf__Page__canvas {
     box-shadow: none !important;
 }
 
+/* remove rectangle when focus over the country/global */
+path.leaflet-interactive:focus {
+  outline: none;
+}
+
 /* .svg color */
 .svg-icon path {
     fill: black;


### PR DESCRIPTION
I deactivated the outline in global.css which is enabled by default by assigning outline: none. 