### PR TITLE
memoize AlertContainer

### DIFF
--- a/src/components/Map/Alerts/AlertContainer.tsx
+++ b/src/components/Map/Alerts/AlertContainer.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { CountryMapDataWrapper } from '@/domain/entities/country/CountryMapData';
 import { AlertType } from '@/domain/enums/AlertType';
@@ -6,7 +8,7 @@ import { ConflictLayer } from './ConflictLayer';
 import { CountryAlertsLayer } from './CountryAlerts/CountryAlertsLayer';
 import { HazardLayer } from './HazardLayer';
 
-export function AlertContainer({ countries }: { countries: CountryMapDataWrapper }) {
+export const AlertContainer = React.memo(({ countries }: { countries: CountryMapDataWrapper }) => {
   const { selectedAlert } = useSelectedAlert();
 
   switch (selectedAlert) {
@@ -17,6 +19,6 @@ export function AlertContainer({ countries }: { countries: CountryMapDataWrapper
     case AlertType.COUNTRY_ALERTS:
       return <CountryAlertsLayer countries={countries} />;
     default:
-      return null; // TODO: hazard layers
+      return null;
   }
-}
+});


### PR DESCRIPTION
The rerendering of the AlertContainer (well, mostly the ConflictLayer) takes a long time, so we want to avoid rerenders unless the props or the context values have changed. 

(The map type change was slow previously when the conflict alerts were selected, that happened because the Map component is subscribed to the selectedMap changes, so on every change it rerendered itself and it's children, including the alert layers.)