### PR TITLE
feat: added line chart y-axis labels

### DIFF
--- a/src/operations/charts/LineChartOperations.ts
+++ b/src/operations/charts/LineChartOperations.ts
@@ -9,6 +9,7 @@ import { CurrencyExchangeGraph } from '@/domain/entities/charts/CurrencyExchange
 import { InflationGraphs } from '@/domain/entities/charts/InflationGraphs.ts';
 import { LineChartData } from '@/domain/entities/charts/LineChartData.ts';
 import { LineChartDataType } from '@/domain/enums/LineChartDataType.ts';
+import { formatToMillion } from '@/utils/formatting.ts';
 
 if (typeof Highcharts === 'object') {
   highchartsMore(Highcharts);
@@ -85,11 +86,12 @@ export default class LineChartOperations {
         return {
           type: LineChartDataType.LINE_CHART_DATA,
           xAxisType: 'datetime',
+          yAxisLabel: 'Mill',
           lines: [
             {
               name: 'Balance of Trade',
               dataPoints: data.data.map((p) => {
-                return { x: new Date(p.x).getTime(), y: p.y };
+                return { x: new Date(p.x).getTime(), y: formatToMillion(p.y) };
               }),
             },
           ],
@@ -99,6 +101,7 @@ export default class LineChartOperations {
         return {
           type: LineChartDataType.LINE_CHART_DATA,
           xAxisType: 'datetime',
+          yAxisLabel: 'Exchange rate',
           lines: [
             {
               name: data.name,
@@ -113,6 +116,7 @@ export default class LineChartOperations {
         return {
           type: LineChartDataType.LINE_CHART_DATA,
           xAxisType: 'datetime',
+          yAxisLabel: 'Rate in %',
           lines: [
             {
               name: 'Headline Inflation',


### PR DESCRIPTION
Checked all line charts again - did the following changes:
- Added y-axis labels:
    - Headline and food inflation: “Rate in %”
    - Balance of Trade: “Mill”
    - Currency Exchange: “Exchange rate”
- Changed Balance of Trade number formatting to “millions”:

open: @marinovl7 @bohdangarchu - I noticed that on the original HungerMap website, all the line charts are 'rounded.' I’ve already implemented the option to enable this rounding in our line chart component. I could activate it for all charts? However, theoretically, a non-rounded line chart is, of course, ' statistically cleaner’/‘more scientific’ ?