### PR TITLE
feat: add loading to accordions of download portal with the help load…

### DIFF
--- a/src/app/download-portal/loading.tsx
+++ b/src/app/download-portal/loading.tsx
@@ -1,0 +1,23 @@
+import AccordionContainer from '@/components/Accordions/AccordionContainer';
+import { TITLE } from '@/domain/entities/download/Country';
+
+export default function Loading() {
+  const loading = true;
+
+  return (
+    <div>
+      <h1>Download Portal</h1>
+      <AccordionContainer
+        items={[
+          {
+            title: 'Country Reports',
+          },
+          {
+            title: TITLE,
+          },
+        ]}
+        loading={loading}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
loading indicator to accordion items of download portal with the help of loading.tsx.
If network is 3g, originally you can't open accordion. 
This is what it looks like right now
![Screenshot 2024-12-08 at 21 53 47](https://github.com/user-attachments/assets/12a6a78e-6d3a-4ba9-8b34-3094c57d33df)
