### PR TITLE
use mapbox tilelayer as base

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -3,17 +3,10 @@ import 'leaflet/dist/leaflet.css';
 import { Feature, FeatureCollection, GeoJSON, GeoJsonProperties, Geometry } from 'geojson';
 import L, { Map as LeafletMap } from 'leaflet';
 import { useEffect, useRef, useState } from 'react';
-import { GeoJSON as LeafletGeoJSON, MapContainer, Pane, SVGOverlay, TileLayer } from 'react-leaflet';
+import { GeoJSON as LeafletGeoJSON, MapContainer, Pane, TileLayer } from 'react-leaflet';
 
 import BackToGlobalButton from '@/components/Map/BackToGlobalButton';
-import {
-  countryBaseStyle,
-  countryBorderStyle,
-  disputedAreaStyle,
-  MAP_MAX_ZOOM,
-  MAP_MIN_ZOOM,
-  oceanBounds,
-} from '@/domain/constant/map/Map';
+import { countryBorderStyle, disputedAreaStyle, MAP_MAX_ZOOM, MAP_MIN_ZOOM } from '@/domain/constant/map/Map';
 import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
 import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
@@ -109,7 +102,12 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
       <ZoomControl threshold={5} callback={onZoomThresholdReached} />
       <BackToGlobalButton />
 
-      <Pane name="ocean" style={{ zIndex: 0 }}>
+      <Pane name="roads" style={{ zIndex: 1 }}>
+        <TileLayer
+          url={`https://api.mapbox.com/styles/v1/feketesamu/cm4h3vg16012n01r1cz47horn/tiles/256/{z}/{x}/{y}?access_token=${process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}`}
+        />
+      </Pane>
+      {/* <Pane name="ocean" style={{ zIndex: 0 }}>
         <SVGOverlay bounds={oceanBounds}>
           <rect width="100%" height="100%" fill="hsl(var(--nextui-ocean))" />
         </SVGOverlay>
@@ -120,7 +118,7 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
           data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
           style={countryBaseStyle}
         />
-      </Pane>
+      </Pane> */}
       {selectedMapType === GlobalInsight.FOOD && countries.features && (
         <>
           {countries.features.map((country) => (
@@ -188,9 +186,6 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
           style={disputedAreaStyle}
         />
       </Pane>
-
-      <ZoomControl threshold={5} callback={onZoomThresholdReached} />
-      <BackToGlobalButton />
     </MapContainer>
   );
 }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -6,13 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { GeoJSON as LeafletGeoJSON, MapContainer, Pane, SVGOverlay, TileLayer } from 'react-leaflet';
 
 import BackToGlobalButton from '@/components/Map/BackToGlobalButton';
-import {
-  countryBorderStyle,
-  disputedAreaStyle,
-  MAP_MAX_ZOOM,
-  MAP_MIN_ZOOM,
-  oceanBounds,
-} from '@/domain/constant/map/Map';
+import { disputedAreaStyle, MAP_MAX_ZOOM, MAP_MIN_ZOOM, oceanBounds } from '@/domain/constant/map/Map';
 import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
 import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
@@ -180,12 +174,12 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
         />
       )}
 
-      <Pane name="countries_border" style={{ zIndex: 3 }}>
+      {/* <Pane name="countries_border" style={{ zIndex: 3 }}>
         <LeafletGeoJSON
           data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
           style={countryBorderStyle}
         />
-      </Pane>
+      </Pane> */}
       <Pane name="disputed_areas" style={{ zIndex: 4 }}>
         <LeafletGeoJSON
           data={MapOperations.convertCountriesToFeatureCollection(disputedAreas.features)}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -3,10 +3,16 @@ import 'leaflet/dist/leaflet.css';
 import { Feature, FeatureCollection, GeoJSON, GeoJsonProperties, Geometry } from 'geojson';
 import L, { Map as LeafletMap } from 'leaflet';
 import { useEffect, useRef, useState } from 'react';
-import { GeoJSON as LeafletGeoJSON, MapContainer, Pane, TileLayer } from 'react-leaflet';
+import { GeoJSON as LeafletGeoJSON, MapContainer, Pane, SVGOverlay, TileLayer } from 'react-leaflet';
 
 import BackToGlobalButton from '@/components/Map/BackToGlobalButton';
-import { countryBorderStyle, disputedAreaStyle, MAP_MAX_ZOOM, MAP_MIN_ZOOM } from '@/domain/constant/map/Map';
+import {
+  countryBorderStyle,
+  disputedAreaStyle,
+  MAP_MAX_ZOOM,
+  MAP_MIN_ZOOM,
+  oceanBounds,
+} from '@/domain/constant/map/Map';
 import { useSelectedAlert } from '@/domain/contexts/SelectedAlertContext';
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
 import { useSelectedMap } from '@/domain/contexts/SelectedMapContext';
@@ -107,12 +113,12 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
           url={`https://api.mapbox.com/styles/v1/feketesamu/cm4h3vg16012n01r1cz47horn/tiles/256/{z}/{x}/{y}?access_token=${process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}`}
         />
       </Pane>
-      {/* <Pane name="ocean" style={{ zIndex: 0 }}>
+      <Pane name="ocean" style={{ zIndex: 0 }}>
         <SVGOverlay bounds={oceanBounds}>
           <rect width="100%" height="100%" fill="hsl(var(--nextui-ocean))" />
         </SVGOverlay>
       </Pane>
-      <Pane name="countries_base" style={{ zIndex: 1 }}>
+      {/* <Pane name="countries_base" style={{ zIndex: 1 }}>
         <LeafletGeoJSON
           interactive={false}
           data={MapOperations.convertCountriesToFeatureCollection(countries.features)}


### PR DESCRIPTION
**Original problem with the new 100% Leaflet map:** We now use leaflet to render a GeoJSON object for each country. However, leaflet is a bit lazy with rendering, so it doesn't render while you're dragging the map. This means that when you drag the map but don't let go of the mouse, you cannot see the new countries that are now in your view.

**Solution:** Create a tile layer in mapbox that contains the countries, so we don't have to render them with leaflet. 

Problems with this solution:
- The hover and inactive overlays are still rendered with leaflet. Because they're dynamic, they can't be part of the Mapbox baselayer. However, the original issue arises with these objects: when dragging, the new ones are not rendered. It's less bad than the original issue, but not ideal.
- It's currently using the country border data of Mapbox, not the adm0data. This is a higher resolution and also includes Kosovo (which was weirdly not included in adm0data), so there are some inconsistencies between the base layer and the hover overlays. We could solve this by uploading the adm0data.json as a source to mapbox. If this data is ever expected to change, we could create a lambda function to update the adm0data.json every day using the Mapbox API. But this is a lot of work for something that's still not the ideal solution (doesn't fix the previous problem)
- On a free mapbox account, only 200K requests to the static tiles API are free. I used just 500 with messing around with the map for about 1 hour, so this wouldn't be enough for production. But WFP might have a paid account, if they do, then no problem, if they don't, then we must ditch this approach.
- light mode doesn't work. This can be fixed rather easily, I was just too lazy to implement it until we decided how to proceed. Although changing between the modes might be a bit slower in this case, since a new tilelayer would have to be loaded