### PR TITLE
feat: configure error page

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -9,6 +9,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
   useEffect(() => {
     // Log the error to an error reporting service
     /* eslint-disable no-console */
+    console.error(error);
   }, [error]);
 
   return (

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,25 +2,34 @@
 
 import { useEffect } from 'react';
 
-export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+import { CustomButton } from '@/components/Buttons/CustomButton';
+import { Topbar } from '@/components/Topbar/Topbar';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     // Log the error to an error reporting service
     /* eslint-disable no-console */
-    console.error(error);
   }, [error]);
 
   return (
-    <div>
-      <h2>Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
-      >
-        Try again
-      </button>
+    <div className="flex flex-col h-screen">
+      <Topbar />
+      <main className="flex h-full flex-col items-center justify-center gap-2 text-content">
+        <section className="text-center">
+          <h2 className="text-xl font-semibold">An Error Occurred</h2>
+          <p>Please try again or go back to the Home page.</p>
+        </section>
+        <div className="flex flex-row gap-2 mt-4">
+          <CustomButton variant="solid" size="lg" onClick={() => reset()}>
+            Try again
+          </CustomButton>
+          <a href="/">
+            <CustomButton variant="solid" size="lg">
+              Go to Home page
+            </CustomButton>
+          </a>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,8 +9,8 @@ export default function NotFound() {
       <Topbar />
       <main className="flex h-full flex-col items-center justify-center gap-2 text-content">
         <section className="text-center">
-          <h2 className="text-xl font-semibold">404 Not Found</h2>
-          <p>Could not find the requested resource.</p>
+          <h2 className="text-xl font-semibold">Ooops</h2>
+          <p>The requested page could not be found.</p>
         </section>
         <div className="flex flex-row gap-2 mt-4">
           <a href="/">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { CustomButton } from '@/components/Buttons/CustomButton';
+import { Topbar } from '@/components/Topbar/Topbar';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col h-screen">
+      <Topbar />
+      <main className="flex h-full flex-col items-center justify-center gap-2 text-content">
+        <section className="text-center">
+          <h2 className="text-xl font-semibold">404 Not Found</h2>
+          <p>Could not find the requested resource.</p>
+        </section>
+        <div className="flex flex-row gap-2 mt-4">
+          <a href="/">
+            <CustomButton variant="solid" size="lg">
+              Go to Home page
+            </CustomButton>
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
This branch implements a common error page to display when an error occurs
---
### Changes introduced:
- Adjusted error.tsx file with custom styling
- Added not-available.tsx for handling 404 errors
- Added buttons for navigating back to home and/or trying to re-render via built-in reset() function
---
- adds topbar without the chatbot to the pages
- uses custom designs (button, text etc.)
- supports mobile and desktop
---
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/cb3c7d8b-b59c-4e6d-94f8-63e3ffa7bd5d" />

---

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/bd7490a5-6380-44e1-bc7a-d6819007e1f9" />
