### PR TITLE
Feature/f 182 chart modal close button

### DIFF
--- a/src/components/Charts/helpers/ChartContainer.tsx
+++ b/src/components/Charts/helpers/ChartContainer.tsx
@@ -70,7 +70,7 @@ export function ChartContainer({
             {
               // button to switch between different chart types
               alternativeSwitchButtonProps && (
-                <ChartAlternativeSwitchButton {...alternativeSwitchButtonProps} size={4} />
+                <ChartAlternativeSwitchButton {...alternativeSwitchButtonProps} size={ICON_BUTTON_SIZE} />
               )
             }
             {

--- a/src/components/Charts/helpers/ChartContainer.tsx
+++ b/src/components/Charts/helpers/ChartContainer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Button } from '@nextui-org/button';
 import { useDisclosure } from '@nextui-org/modal';
 import Highcharts from 'highcharts';

--- a/src/components/Charts/helpers/ChartModal.tsx
+++ b/src/components/Charts/helpers/ChartModal.tsx
@@ -9,7 +9,6 @@ import ChartAlternativeSwitchButton from '@/components/Charts/helpers/buttons/Ch
 import ChartDownloadButton from '@/components/Charts/helpers/buttons/ChartDownloadButton';
 import ChartSliderButton from '@/components/Charts/helpers/buttons/ChartSliderButton';
 import ChartSlider from '@/components/Charts/helpers/ChartSlider';
-import { Tooltip } from '@/components/Tooltip/Tooltip';
 import ChartModalProps from '@/domain/props/ChartModalProps';
 
 /**
@@ -40,11 +39,18 @@ export function ChartModal({
       backdrop="blur"
       scrollBehavior="inside"
       onOpenChange={onOpenChange}
-      hideCloseButton
       className="bg-background"
+      classNames={{
+        closeButton: 'mt-3 rounded-lg mr-3',
+      }}
+      closeButton={
+        <Button isIconOnly variant="light" size="sm" onPress={onClose}>
+          <Minus className="h-4 w-4" />
+        </Button>
+      }
     >
       <ModalContent>
-        <ModalHeader className="flex flex-col gap-1">
+        <ModalHeader className="flex flex-col gap-1 mr-12">
           <div className="flex flex-row justify-between w-full h-full">
             <h2 className="flex flex-col justify-center font-normal text-sm sm:text-md md:text-lg"> {title} </h2>
             <div className="flex flex-row w-fit h-full gap-0.5 sm:gap-4 md:gap-6">
@@ -57,13 +63,6 @@ export function ChartModal({
               )}
 
               {!disableDownload && <ChartDownloadButton chartRef={chartRef} chartData={chartData} size={4} />}
-
-              {/* close model button */}
-              <Tooltip text="Close">
-                <Button isIconOnly variant="light" size="sm" onPress={onClose}>
-                  <Minus className="h-4 w-4" />
-                </Button>
-              </Tooltip>
             </div>
           </div>
         </ModalHeader>

--- a/src/components/Charts/helpers/ChartModal.tsx
+++ b/src/components/Charts/helpers/ChartModal.tsx
@@ -55,14 +55,12 @@ export function ChartModal({
             <h2 className="flex flex-col justify-center font-normal text-sm sm:text-md md:text-lg"> {title} </h2>
             <div className="flex flex-row w-fit h-full gap-0.5 sm:gap-4 md:gap-6">
               {sliderProps && showSlider && setShowSlider && (
-                <ChartSliderButton showSlider={showSlider} setShowSlider={setShowSlider} size={4} />
+                <ChartSliderButton showSlider={showSlider} setShowSlider={setShowSlider} />
               )}
 
-              {alternativeSwitchButtonProps && (
-                <ChartAlternativeSwitchButton {...alternativeSwitchButtonProps} size={4} />
-              )}
+              {alternativeSwitchButtonProps && <ChartAlternativeSwitchButton {...alternativeSwitchButtonProps} />}
 
-              {!disableDownload && <ChartDownloadButton chartRef={chartRef} chartData={chartData} size={4} />}
+              {!disableDownload && <ChartDownloadButton chartRef={chartRef} chartData={chartData} />}
             </div>
           </div>
         </ModalHeader>

--- a/src/components/Charts/helpers/ChartSlider.tsx
+++ b/src/components/Charts/helpers/ChartSlider.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Slider } from '@nextui-org/slider';
 
 import { ChartSliderProps } from '@/domain/props/ChartContainerProps';

--- a/src/components/Charts/helpers/buttons/ChartDownloadButton.tsx
+++ b/src/components/Charts/helpers/buttons/ChartDownloadButton.tsx
@@ -10,12 +10,12 @@ import ChartDownloadButtonOperations from '@/operations/charts/ChartDownloadButt
  * This component is tied to the `ChartContainer` and `ChartModal` component and should not be used independently.
  * It renders a button to open a dropdown menu to download the chart as csv, png, etc.
  */
-export default function ChartDownloadButton({ chartRef, chartData, size }: ChartDownloadButtonProps) {
+export default function ChartDownloadButton({ chartRef, chartData, size = 4 }: ChartDownloadButtonProps) {
   return (
     <Popover placement="bottom" offset={10} backdrop="opaque">
       <PopoverTrigger>
         <Button isIconOnly variant="light" size="sm">
-          <Tooltip text="Export Chart / Data">
+          <Tooltip text="Export Chart / Data" offset={20}>
             <DocumentDownload className={`h-${size} w-${size}`} />
           </Tooltip>
         </Button>

--- a/src/components/Charts/helpers/buttons/ChartSliderButton.tsx
+++ b/src/components/Charts/helpers/buttons/ChartSliderButton.tsx
@@ -7,7 +7,7 @@ import { LineChartSliderButtonProps } from '@/domain/props/ChartContainerProps';
 /**
  * This component is tied to the `ChartContainer` and `ChartModal` component and should not be used independently.
  */
-export default function ChartSliderButton({ showSlider, setShowSlider, size }: LineChartSliderButtonProps) {
+export default function ChartSliderButton({ showSlider, setShowSlider, size = 4 }: LineChartSliderButtonProps) {
   return (
     <Tooltip text="x-Axis Slider">
       <Button

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,10 +14,10 @@ import TooltipProps from '@/domain/props/TooltipProps';
  * @param warning selected if the tooltip should be highlighted (optional)
  * @param titleStyle tailwind classes to style the title (optional)
  * @param textStyle tailwind classes to style the text (optional)
+ * @param offset offset of the tooltip, default is set to 10 (optional)
  * @constructor
  */
-export function Tooltip({ children, title, text, delay, warning, titleStyle, textStyle }: TooltipProps) {
-  const OFFSET: number = 10;
+export function Tooltip({ children, title, text, delay, warning, titleStyle, textStyle, offset = 10 }: TooltipProps) {
   const RADIUS = 'sm';
   const SHADOW = 'md';
   const COLOR = 'default';
@@ -39,7 +39,7 @@ export function Tooltip({ children, title, text, delay, warning, titleStyle, tex
       content={tooltipContent}
       color={COLOR}
       delay={delay || 0}
-      offset={OFFSET}
+      offset={offset}
       radius={RADIUS}
       shadow={SHADOW}
     >

--- a/src/domain/props/ChartContainerProps.tsx
+++ b/src/domain/props/ChartContainerProps.tsx
@@ -13,7 +13,7 @@ import { ChartType } from '@/domain/enums/ChartType.ts';
 export interface LineChartSliderButtonProps {
   showSlider: boolean;
   setShowSlider: Dispatch<SetStateAction<boolean>>;
-  size: number;
+  size?: number;
 }
 
 export interface ChartAlternativeSwitchButtonProps {
@@ -35,7 +35,7 @@ export interface ChartSliderProps {
 export interface ChartDownloadButtonProps {
   chartRef: MutableRefObject<HighchartsReact.RefObject | null>;
   chartData: LineChartData | CategoricalChartData;
-  size: number;
+  size?: number;
 }
 
 /**

--- a/src/domain/props/TooltipProps.tsx
+++ b/src/domain/props/TooltipProps.tsx
@@ -8,4 +8,5 @@ export default interface TooltipProps {
   warning?: boolean;
   titleStyle?: string;
   textStyle?: string;
+  offset?: number;
 }


### PR DESCRIPTION
[F-182](https://linear.app/world-food-programme-wfp/issue/F-182/chart-modal-close-button)

Trigger bug: enlarge chart -> play around with x-axis slider -> close chart => no button is clickable any more on the entire screen

Thanks @bohdangarchu  for the prior research -> I also recognized that as soon as I add a tooltip to the close button, the error reappears. I have done some research but cant find a clear reason. I think the simplest solution would be to omit the tooltip for the close button -> would that be okay?