### PR TITLE
Improve GeoJSON visibility during pan

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -38,6 +38,7 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
   const { resetAlert } = useSelectedAlert();
   const { selectedCountryId, setSelectedCountryId } = useSelectedCountryId();
   const { closeSidebar } = useSidebar();
+  const [renderer] = useState(new L.SVG({ padding: 0.5 }));
 
   const [countryData, setCountryData] = useState<CountryData | undefined>();
   const [countryIso3Data, setCountryIso3Data] = useState<CountryIso3Data | undefined>();
@@ -124,6 +125,7 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
       ref={mapRef}
       center={[21.505, -0.09]}
       zoom={3}
+      renderer={renderer}
       maxBounds={[
         [-90, -180],
         [90, 180],


### PR DESCRIPTION
Far from an ideal solution, but it's better. No idea why only the base and inactive layers are preloaded and not the borders. Keep in mind that this solution most likely made our app harder to run by the browser. We can play around with the padding value, but below 0.5 the effect is not so recognizable.

https://leafletjs.com/reference.html#renderer-padding