### PR TITLE
Improve panning animation

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -140,18 +140,31 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
       <ZoomControl threshold={SELECTED_COUNTRY_ZOOM_THRESHOLD} callback={onZoomThresholdReached} />
       <BackToGlobalButton />
 
+      {/* Ocean */}
       <Pane name="ocean" style={{ zIndex: 0 }}>
         <SVGOverlay bounds={oceanBounds}>
           <rect width="100%" height="100%" fill="hsl(var(--nextui-ocean))" />
         </SVGOverlay>
       </Pane>
-      <Pane name="countries_base" style={{ zIndex: 1 }}>
-        <LeafletGeoJSON
-          interactive={false}
-          data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
-          style={countryBaseStyle}
-        />
-      </Pane>
+
+      {/* Countries */}
+      <LeafletGeoJSON
+        interactive={false}
+        data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
+        style={countryBaseStyle}
+      />
+
+      {/* Country borders */}
+      <LeafletGeoJSON
+        data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
+        style={countryBorderStyle}
+      />
+
+      {/* Disputed areas */}
+      <LeafletGeoJSON
+        data={MapOperations.convertCountriesToFeatureCollection(disputedAreas.features)}
+        style={disputedAreaStyle}
+      />
       {selectedMapType === GlobalInsight.FOOD && countries.features && (
         <>
           {countries.features.map((country) => (
@@ -170,7 +183,7 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
             />
           ))}
           {!selectedCountryId && (
-            <Pane name="fcs_raster" style={{ zIndex: 2 }}>
+            <Pane name="fcs_raster" style={{ zIndex: 401 }}>
               <TileLayer url="https://static.hungermapdata.org/proteus_tiles/{z}/{x}/{y}.png" tms />
             </Pane>
           )}
@@ -191,13 +204,13 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
         ))}
 
       {selectedMapType === GlobalInsight.VEGETATION && (
-        <Pane name="vegetation_raster" style={{ zIndex: 2 }}>
+        <Pane name="vegetation_raster" style={{ zIndex: 401 }}>
           <TileLayer url="https://dev.api.earthobservation.vam.wfp.org/tiles/latest/viq_dekad/{z}/{x}/{y}.png" />
         </Pane>
       )}
 
       {selectedMapType === GlobalInsight.RAINFALL && (
-        <Pane name="vegetation_raster" style={{ zIndex: 2 }}>
+        <Pane name="vegetation_raster" style={{ zIndex: 401 }}>
           <TileLayer url="https://dev.api.earthobservation.vam.wfp.org/tiles/latest/r3q_dekad/{z}/{x}/{y}.png" />
         </Pane>
       )}
@@ -211,19 +224,6 @@ export default function Map({ countries, disputedAreas, fcsData, alertData }: Ma
           countryIso3Data={countryIso3Data}
         />
       )}
-
-      <Pane name="countries_border" style={{ zIndex: 3 }}>
-        <LeafletGeoJSON
-          data={MapOperations.convertCountriesToFeatureCollection(countries.features)}
-          style={countryBorderStyle}
-        />
-      </Pane>
-      <Pane name="disputed_areas" style={{ zIndex: 4 }}>
-        <LeafletGeoJSON
-          data={MapOperations.convertCountriesToFeatureCollection(disputedAreas.features)}
-          style={disputedAreaStyle}
-        />
-      </Pane>
     </MapContainer>
   );
 }

--- a/src/operations/map/FcsChoroplethOperations.ts
+++ b/src/operations/map/FcsChoroplethOperations.ts
@@ -30,7 +30,7 @@ class FcsChoroplethOperations {
     const pathLayer = layer as L.Path;
 
     pathLayer.on({
-      click: async () => {
+      click: () => {
         if (this.checkIfActive(feature as CountryMapData, fcsData)) {
           FcsChoroplethOperations.handleCountryClick(feature, setSelectedCountryId);
           document.getElementsByClassName('leaflet-container').item(0)?.classList.remove('interactive');


### PR DESCRIPTION
Continuation of #160 

It turns out that GeoJSONs not on the default Pane are unaffected by the padding value of the SVG renderer. Previously, Panes were used to set the zIndex of each layer, because Leaflet has some weird default values. Now that we can't use Panes with the GeoJson layers, their default zIndex is 400, so I adjusted the other layers based on this.

The result is still not ideal, but I think this is the best we can do with leaflet. If you pan a lot without letting go of the mouse, you'll still see countries that don't load, but I think it's almost unnoticeable with regular use.

Keep in mind that this solution is supposedly harder to run in browsers, but I didn't notice any performance degradation. If somebody does on their machine, please let me know.