### PR TITLE
Feature/f 186 multiple tooltips are being shown for countries

### DIFF
--- a/src/components/Map/FcsMap/FcsChoropleth.tsx
+++ b/src/components/Map/FcsMap/FcsChoropleth.tsx
@@ -1,12 +1,9 @@
-import { Feature } from 'geojson';
 import L from 'leaflet';
 import { useTheme } from 'next-themes';
 import React, { useEffect, useRef } from 'react';
 import { GeoJSON, useMap } from 'react-leaflet';
 
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
-import { CountryMapData } from '@/domain/entities/country/CountryMapData.ts';
-import { LayerWithFeature } from '@/domain/entities/map/LayerWithFeature.ts';
 import FcsChoroplethProps from '@/domain/props/FcsChoroplethProps';
 import { AccessibilityOperations } from '@/operations/map/AccessibilityOperations';
 import FcsChoroplethOperations from '@/operations/map/FcsChoroplethOperations';
@@ -39,37 +36,7 @@ export default function FcsChoropleth({
   // adding the country name as a tooltip to each layer (on hover); the tooltip is not shown if the country is selected
   useEffect(() => {
     if (!geoJsonRef.current || !map) return () => {};
-
-    const disableTooltips = () => {
-      geoJsonRef.current?.eachLayer((layer) => {
-        if (layer instanceof L.Path) {
-          const layerElement = layer.getElement();
-          if (layerElement && !layerElement.matches(':hover')) {
-            layer.unbindTooltip();
-          }
-        }
-      });
-    };
-
-    const enableTooltips = () => {
-      geoJsonRef.current?.eachLayer((layer: LayerWithFeature) => {
-        const feature = layer.feature as Feature;
-        if (FcsChoroplethOperations.checkIfActive(feature as CountryMapData, fcsData)) {
-          const tooltipContainer = MapOperations.createCountryNameTooltipElement(feature?.properties?.adm0_name);
-          layer.bindTooltip(tooltipContainer, { className: 'leaflet-tooltip', sticky: true });
-        }
-      });
-    };
-
-    enableTooltips();
-
-    map.on('dragstart', disableTooltips);
-    map.on('dragend', enableTooltips);
-
-    return () => {
-      map.off('dragstart', disableTooltips);
-      map.off('dragend', enableTooltips);
-    };
+    return MapOperations.handleCountryTooltip(geoJsonRef, map, fcsData);
   }, [selectedCountryId]);
 
   useEffect(() => {

--- a/src/components/Map/NutritionMap/NutritionChoropleth.tsx
+++ b/src/components/Map/NutritionMap/NutritionChoropleth.tsx
@@ -1,4 +1,3 @@
-import { Feature } from 'geojson';
 import L from 'leaflet';
 import { useTheme } from 'next-themes';
 import React, { useEffect, useRef, useState } from 'react';
@@ -6,7 +5,6 @@ import { GeoJSON, useMap } from 'react-leaflet';
 
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
 import { CountryMapData } from '@/domain/entities/country/CountryMapData.ts';
-import { LayerWithFeature } from '@/domain/entities/map/LayerWithFeature.ts';
 import { NutrientType } from '@/domain/enums/NutrientType.ts';
 import { useNutritionQuery } from '@/domain/hooks/globalHooks';
 import NutritionChoroplethProps from '@/domain/props/NutritionChoroplethProps';
@@ -38,37 +36,7 @@ export default function NutritionChoropleth({ data, countryId, onDataUnavailable
   // the tooltip is not shown if the country is selected or there is no data available for the country
   useEffect(() => {
     if (!geoJsonRef.current || !nutritionData || !map) return () => {};
-
-    const disableTooltips = () => {
-      geoJsonRef.current?.eachLayer((layer) => {
-        if (layer instanceof L.Path) {
-          const layerElement = layer.getElement();
-          if (layerElement && !layerElement.matches(':hover')) {
-            layer.unbindTooltip();
-          }
-        }
-      });
-    };
-
-    const enableTooltips = () => {
-      geoJsonRef.current?.eachLayer((layer: LayerWithFeature) => {
-        const feature = layer.feature as Feature;
-        if (NutritionChoroplethOperations.checkIfActive(data.features[0] as CountryMapData, nutritionData)) {
-          const tooltipContainer = MapOperations.createCountryNameTooltipElement(feature?.properties?.adm0_name);
-          layer.bindTooltip(tooltipContainer, { className: 'leaflet-tooltip', sticky: true });
-        }
-      });
-    };
-
-    enableTooltips();
-
-    map.on('dragstart', disableTooltips);
-    map.on('dragend', enableTooltips);
-
-    return () => {
-      map.off('dragstart', disableTooltips);
-      map.off('dragend', enableTooltips);
-    };
+    return MapOperations.handleCountryTooltip(geoJsonRef, map, undefined, nutritionData, data);
   }, [selectedCountryId, nutritionData]);
 
   return (

--- a/src/components/Map/NutritionMap/NutritionChoropleth.tsx
+++ b/src/components/Map/NutritionMap/NutritionChoropleth.tsx
@@ -2,7 +2,7 @@ import { Feature } from 'geojson';
 import L from 'leaflet';
 import { useTheme } from 'next-themes';
 import React, { useEffect, useRef, useState } from 'react';
-import { GeoJSON } from 'react-leaflet';
+import { GeoJSON, useMap } from 'react-leaflet';
 
 import { useSelectedCountryId } from '@/domain/contexts/SelectedCountryIdContext';
 import { CountryMapData } from '@/domain/entities/country/CountryMapData.ts';
@@ -32,22 +32,44 @@ export default function NutritionChoropleth({ data, countryId, onDataUnavailable
   const { theme } = useTheme();
   const { data: nutritionData } = useNutritionQuery(true);
   const [selectedNutrient, setSelectedNutrient] = useState<NutrientType>(NutrientType.MINI_SIMPLE);
+  const map = useMap();
 
   // adding the country name as a tooltip to each layer (on hover)
   // the tooltip is not shown if the country is selected or there is no data available for the country
   useEffect(() => {
-    if (!geoJsonRef.current || !nutritionData) return;
-    geoJsonRef.current.eachLayer((layer: LayerWithFeature) => {
-      if (!layer) return;
-      const feature = layer.feature as Feature;
-      if (NutritionChoroplethOperations.checkIfActive(data.features[0] as CountryMapData, nutritionData)) {
-        const tooltipContainer = MapOperations.createCountryNameTooltipElement(feature?.properties?.adm0_name);
-        layer.bindTooltip(tooltipContainer, { className: 'leaflet-tooltip', sticky: true });
-      } else {
-        layer.unbindTooltip();
-      }
-    });
-  }, [selectedCountryId]);
+    if (!geoJsonRef.current || !nutritionData || !map) return () => {};
+
+    const disableTooltips = () => {
+      geoJsonRef.current?.eachLayer((layer) => {
+        if (layer instanceof L.Path) {
+          const layerElement = layer.getElement();
+          if (layerElement && !layerElement.matches(':hover')) {
+            layer.unbindTooltip();
+          }
+        }
+      });
+    };
+
+    const enableTooltips = () => {
+      geoJsonRef.current?.eachLayer((layer: LayerWithFeature) => {
+        const feature = layer.feature as Feature;
+        if (NutritionChoroplethOperations.checkIfActive(data.features[0] as CountryMapData, nutritionData)) {
+          const tooltipContainer = MapOperations.createCountryNameTooltipElement(feature?.properties?.adm0_name);
+          layer.bindTooltip(tooltipContainer, { className: 'leaflet-tooltip', sticky: true });
+        }
+      });
+    };
+
+    enableTooltips();
+
+    map.on('dragstart', disableTooltips);
+    map.on('dragend', enableTooltips);
+
+    return () => {
+      map.off('dragstart', disableTooltips);
+      map.off('dragend', enableTooltips);
+    };
+  }, [selectedCountryId, nutritionData]);
 
   return (
     <div>

--- a/src/operations/map/MapOperations.tsx
+++ b/src/operations/map/MapOperations.tsx
@@ -6,6 +6,12 @@ import CountryHoverPopover from '@/components/CountryHoverPopover/CountryHoverPo
 import { MAP_MAX_ZOOM, REGION_LABEL_SENSITIVITY, SELECTED_COUNTRY_ZOOM_THRESHOLD } from '@/domain/constant/map/Map.ts';
 import { CommonRegionProperties } from '@/domain/entities/common/CommonRegionProperties';
 import { Feature } from '@/domain/entities/common/Feature';
+import { CountryFcsData } from '@/domain/entities/country/CountryFcsData.ts';
+import { CountryMapData, CountryProps } from '@/domain/entities/country/CountryMapData.ts';
+import { CountryNutrition } from '@/domain/entities/country/CountryNutrition.ts';
+import { LayerWithFeature } from '@/domain/entities/map/LayerWithFeature.ts';
+import FcsChoroplethOperations from '@/operations/map/FcsChoroplethOperations.ts';
+import NutritionChoroplethOperations from '@/operations/map/NutritionChoroplethOperations.ts';
 
 export class MapOperations {
   /**
@@ -88,5 +94,50 @@ export class MapOperations {
       return tooltip;
     }
     return undefined;
+  }
+
+  static handleCountryTooltip(
+    geoJsonRef: React.MutableRefObject<L.GeoJSON | null>,
+    map: L.Map,
+    fcsData?: Record<string, CountryFcsData>,
+    nutritionData?: CountryNutrition,
+    countryMapData?: FeatureCollection<Geometry, CountryProps>
+  ) {
+    const disableTooltips = () => {
+      geoJsonRef.current?.eachLayer((layer) => {
+        if (layer instanceof L.Path) {
+          const layerElement = layer.getElement();
+          if (layerElement && !layerElement.matches(':hover')) {
+            layer.unbindTooltip();
+          }
+        }
+      });
+    };
+
+    const enableTooltips = () => {
+      geoJsonRef.current?.eachLayer((layer: LayerWithFeature) => {
+        layer.unbindTooltip();
+        const feature = layer.feature as CountryMapData;
+        if (
+          (fcsData && FcsChoroplethOperations.checkIfActive(feature as CountryMapData, fcsData)) ||
+          (nutritionData &&
+            countryMapData &&
+            NutritionChoroplethOperations.checkIfActive(countryMapData.features[0] as CountryMapData, nutritionData))
+        ) {
+          const tooltipContainer = MapOperations.createCountryNameTooltipElement(feature?.properties?.adm0_name);
+          layer.bindTooltip(tooltipContainer, { className: 'leaflet-tooltip', sticky: true });
+        }
+      });
+    };
+
+    enableTooltips();
+
+    map.on('dragstart', disableTooltips);
+    map.on('dragend', enableTooltips);
+
+    return () => {
+      map.off('dragstart', disableTooltips);
+      map.off('dragend', enableTooltips);
+    };
   }
 }


### PR DESCRIPTION
The issue was that when dragging the map, the cursor could still hover over other countries and trigger the tooltips.
I now disable all other tooltips than the one of the country that the mouse is currently hovering over and enable them again once the dragging is finished. This should solve the other issue.