### PR TITLE
feature/f-274-social-links-should-lead-to-wfp-pages

### DIFF
--- a/src/components/Subscribe/Subscribe.tsx
+++ b/src/components/Subscribe/Subscribe.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Divider, Input } from '@nextui-org/react';
-import { Facebook, Instagram, Twitch, Youtube } from 'iconsax-react';
+import { Facebook, Global, Instagram, Musicnote, Xrp, Youtube } from 'iconsax-react';
+import { Linkedin } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import container from '@/container';
@@ -192,17 +193,26 @@ export default function SubscriptionForm() {
       </form>
 
       <div className="flex gap-1">
-        <SocialLink href="https://twitch.com/">
-          <Twitch size={24} color="#6441A4" />
-        </SocialLink>
-        <SocialLink href="https://facebook.com/">
+        <SocialLink href="https://www.facebook.com/WorldFoodProgramme">
           <Facebook size={24} color="#1877F2" />
         </SocialLink>
-        <SocialLink href="https://youtube.com/">
+        <SocialLink href="https://www.youtube.com/@WorldFoodProgramme">
           <Youtube size={24} color="#FF0000" />
         </SocialLink>
-        <SocialLink href="https://instagram.com/">
+        <SocialLink href="https://www.instagram.com/Worldfoodprogramme/">
           <Instagram size={24} color="#E1306C" />
+        </SocialLink>
+        <SocialLink href="https://www.wfp.org/">
+          <Global size={24} color="#FF8A65" />
+        </SocialLink>
+        <SocialLink href="https://x.com/WFP">
+          <Xrp size={24} color="#1DA1F2" />
+        </SocialLink>
+        <SocialLink href="https://www.tiktok.com/@worldfoodprogramme">
+          <Musicnote size={24} color="#6441A4" />
+        </SocialLink>
+        <SocialLink href="https://www.linkedin.com/company/unwfp/">
+          <Linkedin size={24} color="#0077B5" />
         </SocialLink>
       </div>
     </div>


### PR DESCRIPTION
This pull request includes updates to the social media links and icons in the `Subscribe` component. The changes involve adding new social media platforms and updating the URLs for existing ones.

Updates to social media links and icons:

* [`src/components/Subscribe/Subscribe.tsx`](diffhunk://#diff-d64c83b8d1a8e7f50321ad6fe2af658780503b38a53524e20c51311c66de0a12L4-R5): Imported new icons `Global`, `Musicnote`, `Xrp`, and `Linkedin` from `iconsax-react` and `lucide-react`.
* [`src/components/Subscribe/Subscribe.tsx`](diffhunk://#diff-d64c83b8d1a8e7f50321ad6fe2af658780503b38a53524e20c51311c66de0a12L195-R216): Updated the URLs for Facebook, Youtube, and Instagram to point to the World Food Programme's official pages.
* [`src/components/Subscribe/Subscribe.tsx`](diffhunk://#diff-d64c83b8d1a8e7f50321ad6fe2af658780503b38a53524e20c51311c66de0a12L195-R216): Added new social media links for the World Food Programme's website, X (formerly Twitter), TikTok, and LinkedIn.