### PR TITLE
feature/f-277-hazard-alerts-cursor-pointer

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -134,6 +134,11 @@ path.leaflet-interactive:focus {
   cursor: pointer;
 }
 
+/* for hazards marker icon */
+.leaflet-marker-icon.leaflet-interactive{
+  cursor: pointer;
+}
+
 .map-marker-with-margin {
   margin: 1px !important;
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/styles/globals.css` file. The change adds a new CSS rule to ensure that the cursor changes to a pointer when hovering over hazard marker icons on the map.

Changes to `src/styles/globals.css`:

* Added a CSS rule for `.leaflet-marker-icon.leaflet-interactive` to set the cursor to pointer.