### PR TITLE
feature/f-292-change-acute-malnutrition-to-chronic-malnutrition-on-the-ipc

### DIFF
--- a/src/operations/map/IpcFoodSecurityOperations.tsx
+++ b/src/operations/map/IpcFoodSecurityOperations.tsx
@@ -113,7 +113,7 @@ export class IpcFoodSecurityAccordionOperations {
           )}
           {nutritionData.Chronic != null && (
             <CustomCard
-              title={descriptions.malnutritionAcute.legendTitle}
+              title={descriptions.malnutritionChronic.legendTitle}
               content={[
                 {
                   svgIcon: <Nutrition className="w-[40px] h-[40px] object-contain" />,


### PR DESCRIPTION
This pull request includes a change to the `IpcFoodSecurityAccordionOperations` class in the `src/operations/map/IpcFoodSecurityOperations.tsx` file. The change updates the title of a `CustomCard` component to use the correct description for chronic malnutrition.

Improvements to component titles:

* [`src/operations/map/IpcFoodSecurityOperations.tsx`](diffhunk://#diff-175284bcd227f8ba3fbf643ffe042a2ebe36e599834f3f41cff385290cba8294L116-R116): Updated the `CustomCard` title to use `descriptions.malnutritionChronic.legendTitle` instead of `descriptions.malnutritionAcute.legendTitle`.


For this PR, I will only change the title, while keeping everything else like icon samely to align with our design style.