### PR TITLE
Feature/f-293 Fix query params for info pages

### DIFF
--- a/src/domain/constant/dataSources/dataSourceDescriptions.tsx
+++ b/src/domain/constant/dataSources/dataSourceDescriptions.tsx
@@ -234,10 +234,8 @@ export const nutritionDescriptions = {
         <ul>
           <li>
             <b>Stunting:</b> Height is lower by &gt; 2{' '}
-            <StyledLink href="https://en.wikipedia.org/wiki/Standard_deviation" className="text-sm">
-              standard deviations
-            </StyledLink>{' '}
-            from the median height for age of reference population
+            <StyledLink href="https://en.wikipedia.org/wiki/Standard_deviation">standard deviations</StyledLink> from
+            the median height for age of reference population
           </li>
           <li>
             <b>Severe stunting:</b> Height is lower by &gt; 3 standard deviations from the median height for age of

--- a/src/domain/constant/dataSources/dataSourceDescriptions.tsx
+++ b/src/domain/constant/dataSources/dataSourceDescriptions.tsx
@@ -255,16 +255,17 @@ export const nutritionDescriptions = {
     legendTitle: 'Risk of Inadequate Micronutrient Intake',
     summary: (
       <span>
-        The <Abbreviation abbreviation="MIMI" /> project is modelling and mapping the risk of inadequate micronutrient
-        intake to inform decision making in the short-medium term.
+        The MIMI project is modelling and mapping the risk of inadequate micronutrient intake to inform decision making
+        in the short-medium term.
       </span>
     ),
     description: (
       <>
         <p>
-          MIMI is helping to close gaps in the nutrition data landscape by applying novel approaches to model and map
-          the risk of inadequate micronutrient intake and potential contribution from fortification scenarios, to inform
-          decision making and advocacy for fortification and other micronutrient programmes in the short-medium term.
+          <Abbreviation abbreviation="MIMI" /> is helping to close gaps in the nutrition data landscape by applying
+          novel approaches to model and map the risk of inadequate micronutrient intake and potential contribution from
+          fortification scenarios, to inform decision making and advocacy for fortification and other micronutrient
+          programmes in the short-medium term.
         </p>
         <p>
           <b>Key components of the current MIMI project:</b>

--- a/src/domain/constant/wiki/wikiEntries.tsx
+++ b/src/domain/constant/wiki/wikiEntries.tsx
@@ -8,6 +8,7 @@ const wikiItems = (
     descriptions.hazards,
     descriptions.malnutritionAcute,
     descriptions.malnutritionChronic,
+    descriptions.micronutrients,
     descriptions.rainfall,
     descriptions.rCsi,
     descriptions.undernourishment,

--- a/src/domain/hooks/queryParamsHooks.ts
+++ b/src/domain/hooks/queryParamsHooks.ts
@@ -177,8 +177,11 @@ export const useSearchQuery = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [searchQuery, setSearchQuery] = useState('');
+  // The query in real-time (should be equal to what's in the search bar)
+  const [searchQuery, setSearchQuery] = useState(searchParams.get(PARAM_NAME) ?? '');
+  // The debounced query (should be equal to what's in the query parameter)
   const debouncedSearch = useDebounce(searchQuery, DEBOUNCE_MS);
+  // True if the last update of the search query came from a key press (not from a URL change)
   const [recentUserInput, setRecentUserInput] = useState(false);
 
   // get state values from query params (on browser navigation)
@@ -188,11 +191,13 @@ export const useSearchQuery = () => {
     else setSearchQuery(searchParams.get(PARAM_NAME) ?? '');
   }, [searchParams]);
 
-  // set query params from debounced state (on search input change)
+  // set query params from debounced state
   useEffect(() => {
-    router.push(`${pathname}?${PARAM_NAME}=${debouncedSearch}`);
+    if (debouncedSearch) router.push(`${pathname}?${PARAM_NAME}=${debouncedSearch}`);
+    else router.push(pathname);
   }, [debouncedSearch]);
 
+  // handle user input
   const setSearchQueryFn = (newValue: string) => {
     setSearchQuery(newValue);
     setRecentUserInput(true);


### PR DESCRIPTION
* fix race condition for query params, which sometimes set them to "" on page load (seems like this happened when I changed sth 3 weeks ago, I wonder why I didn't notice it back then)
* remove the search query param if the search is empty

additional changes:
* fix inconsistent font size for a link on the Wiki page
* fix missing Micronutrient entry in Wiki