### PR TITLE
feat: fix popover closing behaviour

### DIFF
--- a/src/components/InfoPopover/InfoPopover.tsx
+++ b/src/components/InfoPopover/InfoPopover.tsx
@@ -13,7 +13,16 @@ export function InfoPopover({
   popoverInfo: React.ReactNode;
 }) {
   return (
-    <Popover className="m-2">
+    <Popover
+      className="m-2"
+      shouldCloseOnInteractOutside={(element) => {
+        // needed when used inside the accorion
+        if (element.getAttribute('type') === 'button') {
+          return false;
+        }
+        return true;
+      }}
+    >
       <PopoverTrigger>
         <Button as="span" isIconOnly radius="full" className="w-[37px] h-[37px]" variant="light" aria-label="info icon">
           {infoIcon}


### PR DESCRIPTION
When the trigger is clicked, there is immediately another event triggered for clicking outside because of the accordion title button. So we have to check if that outside element is the accordion title button, and if it is, the popover shouldn't close