### PR TITLE
feat: Add small addition info on iOS devices "tap again for details" (iOS Tooltips Option 2)

### DIFF
--- a/src/components/CountryHoverPopover/CountryHoverPopover.tsx
+++ b/src/components/CountryHoverPopover/CountryHoverPopover.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { CountryHoverPopoverProps } from '@/domain/props/CountryHoverPopoverProps';
+import { isIOSTouchDevice } from '@/utils/devices';
 
 export default function CountryHoverPopover({ header, details, summary }: CountryHoverPopoverProps) {
   const headerOnly = header && !details && !summary;
@@ -11,6 +12,7 @@ export default function CountryHoverPopover({ header, details, summary }: Countr
       {header && <h1 className="text-sm font-semibold">{header}</h1>}
       {details && <p className="text-xs">{details}</p>}
       {summary && <p className="text-xs">{summary}</p>}
+      {isIOSTouchDevice() && <span className="text-xs font-light">Tap again for details</span>}
     </div>
   );
 }

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -1,0 +1,6 @@
+export function isIOSTouchDevice(): boolean {
+  return (
+    ['iPad', 'iPhone', 'iPod'].includes(navigator.platform) ||
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  );
+}


### PR DESCRIPTION
Add small addition info on iOS devices "tap again for details"
![IMG_9076](https://github.com/user-attachments/assets/af55f15a-0947-4110-af86-7ffc70450af9)
![IMG_9077](https://github.com/user-attachments/assets/476fbd89-27c0-41e4-b7c8-1849bef4d83e)
